### PR TITLE
Update README.md with information about timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ __`cacheHttpHeader`__
 
 Name of the http header returned in the proxy response with the value `"hit"` or `"miss"`. Defaults to `"Express-Request-Proxy-Cache"`.
 
+__`timeout`__
+
+The number of milliseconds to wait for a server to send response headers before aborting the request. See [request/request](https://github.com/request/request#user-content-requestoptions-callback) for more information. Default value `5000`.
 
 #### HTTP Basic Auth
 For http endpoints protected by [HTTP Basic authentication](http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side), a username and password should be sent in the form `username:password`  which is then base64 encoded.


### PR DESCRIPTION
We had a problem with sporadic failures with the default settings due to a slow backend server. It turns out the default timeout value (5 seconds) had to be increased, however, the default value was nowhere to be found in the documentation. This PR adds documentation on the timeout property and its default value so that other users don't have to spend time looking of this value in the source code.