### PR TITLE
Patch/configuration/response headers

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,7 +9,6 @@ var _ = require('lodash'),
 
 require('simple-errors');
 
-var discardApiResponseHeaders = ['set-cookie', 'content-length'];
 
 // Headers from the original API response that should be preserved and sent along
 // in cached responses.
@@ -17,6 +16,10 @@ var headersToPreserveInCache = ['content-type'];
 
 /* eslint-disable consistent-return */
 module.exports = function(options) {
+  
+  // Allow discarding response headers to be configurable
+  var discardApiResponseHeaders = options.discardApiResponseHeaders || ['set-cookie', 'content-length'];
+
   options = _.defaults(options || {}, {
     ensureAuthenticated: false,
     cache: null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-request-proxy",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Intelligent http proxy Express middleware",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Is there a specific reason why set-cookie is blocked?

Allow discarding response headers to be configurable