### PR TITLE
Abort api request when first request is cancelled

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -75,12 +75,20 @@ module.exports = function(options) {
 
     // If the req has a body, pipe it into the proxy request
     var apiRequest;
+    var originalApiRequest;
     if (is.hasBody(req)) {
       debug('piping req body to remote http endpoint');
-      apiRequest = req.pipe(request(apiRequestOptions));
+      originalApiRequest = request(apiRequestOptions);
+      apiRequest = req.pipe(originalApiRequest);
     } else {
       apiRequest = request(apiRequestOptions);
+      originalApiRequest = apiRequest;
     }
+
+    // Abort api request if client close its connection
+    req.on('close', function() {
+      originalApiRequest.abort();
+    });
 
     apiRequest.on('error', function(err) {
       unhandledApiError(err, next);

--- a/test/abort.js
+++ b/test/abort.js
@@ -14,10 +14,10 @@ describe('request abortion', function() {
   beforeEach(function() {
     this.remoteApi.get('/longRoute', function(req, res) {
       var closedBeforeSend = false;
-      req.on('close', () => {
+      req.on('close', function() {
         closedBeforeSend = true;
       })
-      setTimeout(() => {
+      setTimeout(function() {
         fullyExecuted = !closedBeforeSend;
         res.send({status: true});
       }, remoteRequestDelay);

--- a/test/abort.js
+++ b/test/abort.js
@@ -1,0 +1,57 @@
+var supertest = require('supertest');
+var request = require('request');
+var proxy = require('..');
+var setup = require('./setup');
+
+describe('request abortion', function() {
+  var self;
+  var fullyExecuted = false;
+  var remoteRequestDelay = 50;
+
+  beforeEach(setup.beforeEach);
+  afterEach(setup.afterEach);
+
+  beforeEach(function() {
+    this.remoteApi.get('/longRoute', function(req, res) {
+      var closedBeforeSend = false;
+      req.on('close', () => {
+        closedBeforeSend = true;
+      })
+      setTimeout(() => {
+        fullyExecuted = !closedBeforeSend;
+        res.send({status: true});
+      }, remoteRequestDelay);
+    });
+    this.server.get('/proxyLongRoute', proxy({
+      url: 'http://localhost:' + this.apiPort + '/longRoute',
+      cache: false
+    }));
+  });
+
+  it('should process the remote api request fully if client do not close prematurely connection', function(done) {
+    fullyExecuted = false;
+    supertest(this.server)
+      .get('/proxyLongRoute')
+      .expect(200)
+      .end(function(err, res) {
+        if (!fullyExecuted) return done(new Error('Not fully executed'));
+        done();
+      });
+  });
+
+  it('should cancel the remote api request fully if client do not close prematurely connection', function(done) {
+    var self = this;
+    this.server.listen(this.apiPort + 1, function() {
+      fullyExecuted = false;
+      var req = request({
+        url: 'http://localhost:' + (self.apiPort + 1) + '/proxyLongRoute'
+      });
+      // Abort main request after 250ms.
+      setTimeout(function() { req.abort(); }, remoteRequestDelay / 2);
+      setTimeout(function() {
+        if (!fullyExecuted) return done();
+        done(new Error('Request has not been closed.'));
+      }, remoteRequestDelay + 10);
+    });
+  });
+});


### PR DESCRIPTION
Call the abort method of the request object when main request is canceled.

This is useful when express-request-proxy is used to proxify long polling requests.  
In the polling mode of socket.io, when a client disconnects, the long polling request is canceled, but the proxified request persists between the middleware and the remote server.  
The remote server sees the client as connected until the request timeouts.
